### PR TITLE
Add Initial beta version code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,105 @@
+
+# Created by https://www.gitignore.io/api/python
+
+### Python ###
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+.pytest_cache/
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+
+# Translations
+*.mo
+*.pot
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule.*
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+
+
+# End of https://www.gitignore.io/api/python

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: python
+python:
+    - 3.6
+
+# command to install dependencies
+install: "make"
+
+# command to run tests
+script:
+    - make test

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,6 @@
+init:
+	pip install pipenv
+	pipenv install --dev
+
+test:
+	pipenv run python -m unittest tests/mock_tests.py

--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,11 @@
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+
+[dev-packages]
+
+[requires]
+python_version = "3.6"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,0 +1,20 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "415dfdcb118dd9bdfef17671cb7dcd78dbd69b6ae7d4f39e8b44e71d60ca72e7"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "3.6"
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {},
+    "develop": {}
+}

--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
-# labgsheet
+# labgsheet: Labnotes on Google Sheet
+
+[![Build Status](https://travis-ci.org/shotarok/labgsheet.svg?branch=master)](https://travis-ci.org/shotarok/labgsheet)
+
 A python library to note ml experiments on google sheet

--- a/labgsheet/__init__.py
+++ b/labgsheet/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+
+from .labgsheet import Experiment
+
+__all__ = [Experiment]

--- a/labgsheet/labgsheet.py
+++ b/labgsheet/labgsheet.py
@@ -1,0 +1,67 @@
+# -*- coding: utf-8 -*-
+
+import uuid
+
+
+class Experiment(object):
+    HEADER_ROW = 1
+    EXP_ID_COL = 1
+
+    def __init__(self, ws, experiment_id=None):
+        self._ws = ws
+        self._prepare_experiment_header()
+        self.experiment_id = experiment_id or self._uuid()
+        self.row = self._find_or_create_row(self.experiment_id)
+
+    def _uuid(self):
+        return uuid.uuid4().hex
+
+    def _prepare_experiment_header(self):
+        # make sure that 'experiment_id' header exists
+        self._ws.update_cell(self.HEADER_ROW, self.EXP_ID_COL, 'experiment_id')
+
+    def log_parameter(self, name, val):
+        self._update_by_name(name, val)
+
+    def log_multi_params(self, param_dict):
+        for name, val in param_dict.items():
+            self._update_by_name(name, val)
+
+    def log_metric(self, name, val):
+        self._update_by_name(name, val)
+
+    def log_multi_metrics(self, metric_dict):
+        for name, val in metric_dict.items():
+            self._update_by_name(name, val)
+
+    def _update_by_name(self, name, val):
+        col = self._find_or_create_header(name)
+        self._ws.update_cell(self.row, col, val)
+
+    def _find_or_create_row(self, experiment_id):
+        experiment_ids = self._get_experiment_ids()
+        if experiment_id in experiment_ids:
+            return experiment_ids.index(experiment_id) + 1
+
+        # Add a new experiment row when experiment_id does not exist
+        new_exp_row = len(experiment_ids) + 1
+        self._ws.update_cell(
+            new_exp_row, self.EXP_ID_COL, self.experiment_id
+        )
+        return new_exp_row
+
+    def _get_headers(self):
+        return self._ws.row_values(self.HEADER_ROW)
+
+    def _get_experiment_ids(self):
+        return self._ws.col_values(self.EXP_ID_COL)
+
+    def _find_or_create_header(self, name):
+        headers = self._get_headers()
+        if name in headers:
+            return headers.index(name) + 1
+
+        # Add a new header cell when name is not in headers
+        new_h_col = len(headers) + 1
+        self._ws.update_cell(self.HEADER_ROW, new_h_col, name)
+        return new_h_col

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python
+
+from setuptools import find_packages
+from distutils.core import setup
+
+requires = [
+    'gspread'
+]
+
+classifiers = [
+    'Development Status :: 4 - Beta',
+    'License :: OSI Approved :: MIT License',
+    'Operating System :: OS Independent',
+    'Intended Audience :: Developers',
+    'Intended Audience :: Science/Research',
+    'Programming Language :: Python',
+    'Programming Language :: Python :: Implementation :: PyPy',
+]
+
+setup(
+    name='labgsheet',
+    version='0.1.0',
+    packages=find_packages(exclude=['contrib', 'docs', 'tests']),
+    license='MIT',
+    description='A python library to note ml experiments on google sheet',
+    url='https://github.com/shotarok/labgsheet',
+    author='Shotaro Kohama',
+    author_email='khmshtr28@gmail.com',
+    install_requires=requires,
+    classifiers=classifiers
+)

--- a/tests/mock_tests.py
+++ b/tests/mock_tests.py
@@ -1,0 +1,99 @@
+"""A test suite that doesn't query the Google API.
+
+Avoiding direct network access is benefitial in that it markedly speeds up
+testing, avoids error-prone credential setup, and enables validation even if
+internet access is unavailable.
+
+"""
+
+from unittest.mock import Mock
+from unittest.mock import call
+import unittest
+
+from labgsheet import Experiment
+
+
+class MockExperimentTest(unittest.TestCase):
+
+    def setUp(self):
+        self.ws_mock = Mock()
+
+    def test_init(self):
+        self.ws_mock.col_values = Mock(return_value=['experiment_id'])
+        exp = Experiment(self.ws_mock)
+        got = self.ws_mock.method_calls
+        expected = [
+            call.update_cell(1, 1, 'experiment_id'),
+            call.col_values(1),
+            call.update_cell(2, 1, exp.experiment_id)
+        ]
+        self.assertEqual(got, expected)
+        self.assertEqual(exp.row, 2)
+
+    def test_init_with_experiment_id(self):
+        experiment_ids = ['experiment_id', 'exp1', 'exp2', 'exp3']
+        self.ws_mock.col_values = Mock(return_value=experiment_ids)
+        exp = Experiment(self.ws_mock, experiment_id='exp2')
+        got = self.ws_mock.method_calls
+        expected = [
+            call.update_cell(1, 1, 'experiment_id'),
+            call.col_values(1)
+        ]
+        self.assertEqual(got, expected)
+        self.assertEqual(exp.row, 3)
+
+    def test_logging_new_params_and_metrics(self):
+        self.ws_mock.col_values = Mock(return_value=['experiment_id'])
+        headers = [
+            'experiment_id', 'param1', 'metric1', 'param2',
+            'param3', 'metric2', 'metric3'
+        ]
+        self.ws_mock.row_values = Mock(side_effect=[
+            headers[0:i] for i in range(1, len(headers))
+        ])
+        exp = Experiment(self.ws_mock)
+        exp.log_parameter('param1', 1)
+        exp.log_metric('metric1', 10)
+        exp.log_multi_params({'param2': 2, 'param3': 3})
+        exp.log_multi_metrics({'metric2': 20, 'metric3': 30})
+
+        got = self.ws_mock.method_calls
+        expected = [
+            call.update_cell(Experiment.HEADER_ROW, 2, 'param1'),
+            call.update_cell(exp.row, 2, 1),
+            call.update_cell(Experiment.HEADER_ROW, 3, 'metric1'),
+            call.update_cell(exp.row, 3, 10),
+            call.update_cell(Experiment.HEADER_ROW, 4, 'param2'),
+            call.update_cell(exp.row, 4, 2),
+            call.update_cell(Experiment.HEADER_ROW, 5, 'param3'),
+            call.update_cell(exp.row, 5, 3),
+            call.update_cell(Experiment.HEADER_ROW, 6, 'metric2'),
+            call.update_cell(exp.row, 6, 20),
+            call.update_cell(Experiment.HEADER_ROW, 7, 'metric3'),
+            call.update_cell(exp.row, 7, 30),
+        ]
+        self.assertTrue(all([c in got for c in expected]))
+
+    def test_logging_existed_params_and_metrics(self):
+        self.ws_mock.col_values = Mock(return_value=['experiment_id'])
+        headers = [
+            'experiment_id', 'metric1', 'metric2', 'metric3',
+            'param1', 'param2', 'param3'
+        ]
+        self.ws_mock.row_values = Mock(return_value=headers)
+        exp = Experiment(self.ws_mock)
+        exp.log_parameter('param1', 1)
+        exp.log_metric('metric1', 10)
+        exp.log_multi_params({'param2': 2, 'param3': 3})
+        exp.log_multi_metrics({'metric2': 20, 'metric3': 30})
+
+        got = self.ws_mock.method_calls
+        expected = [
+            call.update_cell(exp.row, headers.index('param1') + 1, 1),
+            call.update_cell(exp.row, headers.index('metric1') + 1, 10),
+            call.update_cell(exp.row, headers.index('param2') + 1, 2),
+            call.update_cell(exp.row, headers.index('param3') + 1, 3),
+            call.update_cell(exp.row, headers.index('metric2') + 1, 20),
+            call.update_cell(exp.row, headers.index('metric3') + 1, 30),
+        ]
+        self.assertTrue(all([c in got for c in expected]))


### PR DESCRIPTION
Add Initial beta version `labgsheet` code.

`labgsheet` gives an easy way to note ml experiments on Google Sheet like followings.

```python
# prepare for worksheet by gspread
>>> import gspread
>>> from oauth2client.service_account import ServiceAccountCredentials
>>> scope = ['https://spreadsheets.google.com/feeds', 'https://www.googleapis.com/auth/drive']
>>> credentials = ServiceAccountCredentials.from_json_keyfile_name('credentials.json', scope)
>>> gc = gspread.authorize(credentials)
>>> ws = gc.create("Test for labgsheets").sheet1

# note an experiment where params and a metric are used
>>> from labgsheet import Experiment
>>> exp = Experiment(ws)
>>> exp.log_multi_params({'l1': 0.5, 'C': 10})
>>> exp.log_metric('aupr', 0.2345)
```

![image](https://user-images.githubusercontent.com/1156179/39610145-551243a6-4f89-11e8-9e56-e52057e173e0.png)
